### PR TITLE
Introducing manual build（マニュアルビルドを導入する）

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,12 @@
 name: Build FlyDog SDR Image
 
 on:
-  schedule:
-  - cron: 0 20 * * *
-  release:
-    types: published
+  #schedule:
+  #- cron: 0 20 * * *
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
In this patch, automatic daily builds will be disabled by default (you can re-enable them by modifying workflow). Instead the build process will be triggered manually via a button.
このパッチでは、毎日の自動ビルドがデフォルトで無効になります（ワークフローを変更することで再度有効にすることができます）。代わりに、ボタンを使って手動でビルドプロセスが開始されます。